### PR TITLE
Return 404 for model not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ safety:
 
 ## Run the tests.
 test:
-	docker-compose run --rm -e ENVIRONMENT=testing web \
-		pytest --cov=src/model_warehouse
+	docker-compose run --rm -e ENVIRONMENT=testing -e \
+		POSTGRES_DB_NAME=model_warehouse_test web pytest --cov=src/model_warehouse
 
 ## Run the tests and report coverage (see https://docs.codecov.io/docs/testing-with-docker).
 shared := /tmp/coverage

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ safety:
 
 ## Run the tests.
 test:
-	docker-compose run --rm -e ENVIRONMENT=testing -e \
-		POSTGRES_DB_NAME=model_warehouse_test web pytest --cov=src/model_warehouse
+	docker-compose run --rm -e ENVIRONMENT=testing web pytest \
+		--cov=src/model_warehouse
 
 ## Run the tests and report coverage (see https://docs.codecov.io/docs/testing-with-docker).
 shared := /tmp/coverage

--- a/src/model_warehouse/settings.py
+++ b/src/model_warehouse/settings.py
@@ -106,6 +106,9 @@ class Testing(Default):
         """Initialize the testing environment configuration."""
         super().__init__()
         self.TESTING = True
+        self.SQLALCHEMY_DATABASE_URI = (
+            'postgres://postgres:@postgres:5432/model_warehouse_test'
+        )
 
 
 class Production(Default):

--- a/tests/test_integration/test_endpoints.py
+++ b/tests/test_integration/test_endpoints.py
@@ -65,3 +65,15 @@ def test_indvmodel_delete(client, db, model):
     db.session.commit()
     resp = client.delete("/models/1")
     assert resp.status_code == 200
+
+
+def test_indvmodel_not_found(client, db):
+    """Test that 404 is returned for any GET/PUT/DELETE request to a non-existing model."""
+    resp = client.get("/models/1")
+    assert resp.status_code == 404
+
+    resp = client.put("/models/1")
+    assert resp.status_code == 404
+
+    resp = client.delete("/models/1")
+    assert resp.status_code == 404

--- a/tests/test_integration/test_endpoints.py
+++ b/tests/test_integration/test_endpoints.py
@@ -68,7 +68,12 @@ def test_indvmodel_delete(client, db, model):
 
 
 def test_indvmodel_not_found(client, db):
-    """Test that 404 is returned for any GET/PUT/DELETE request to a non-existing model."""
+    """
+    Test requests for non-existing models.
+
+    404 should be returned for any GET/PUT/DELETE request to a non-existing
+    model id.
+    """
     resp = client.get("/models/1")
     assert resp.status_code == 404
 


### PR DESCRIPTION
This small change handles the case where a requested model is not found and returns HTTP 404 for those cases.

With this, [reports like this](https://sentry.io/technical-university-of-denmark/model-warehouse-staging/issues/674419548/?referrer=slack) won't appear anymore.